### PR TITLE
Add conditional check for core/search block

### DIFF
--- a/assets/js/disable-search.js
+++ b/assets/js/disable-search.js
@@ -1,3 +1,5 @@
 wp?.domReady( () => {
-	wp.blocks.unregisterBlockType( 'core/search' );
+	if ( wp.blocks.getBlockType( 'core/search' ) ) {
+		wp.blocks.unregisterBlockType('core/search');
+	}
 } );


### PR DESCRIPTION
Fix #1 

Check first, if `core/search` block is registered. Attempt to unregister only if true.